### PR TITLE
Add basic esbuild support

### DIFF
--- a/esbuild/index.html
+++ b/esbuild/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Basic Mirador</title>
+  </head>
+  <body>
+    <div id="demo"></div>
+    <script src="../dist/esbuild.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "private": true,
   "scripts": {
+    "esbuild": "esbuild src/index.js --bundle --define:process.env.NODE_ENV=\\\"production\\\" --outfile=dist/esbuild.js --external:domain --minify",
     "parcel": "parcel parcel/index.html",
     "webpack": "webpack --config webpack/webpack.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -12,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "css-loader": "^3.6.0",
+    "esbuild": "^0.8.21",
     "mirador": "^3.0.0",
     "mirador-image-tools": "^0.10.0",
     "parcel-bundler": "^1.12.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Mirador from 'mirador/dist/es/src/index';
-import { miradorImageToolsPlugin } from 'mirador-image-tools';
+// import { miradorImageToolsPlugin } from 'mirador-image-tools';
 
 const config = {
   id: 'demo',
@@ -18,5 +18,5 @@ const config = {
 };
 
 Mirador.viewer(config, [
-  ...miradorImageToolsPlugin,
+  // ...miradorImageToolsPlugin,
 ]);


### PR DESCRIPTION
++ @atomotic for the reccomendation.

Todos:
 - [ ] Figure out why plugins are bundling multiple versions of react